### PR TITLE
Flake + Styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,7 +366,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
 ]
 
 [[package]]
@@ -378,7 +384,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
  "version_check",
 ]
 
@@ -395,18 +401,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -480,7 +486,7 @@ checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
 ]
 
 [[package]]
@@ -523,6 +529,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,7 +556,7 @@ checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
 ]
 
 [[package]]
@@ -568,9 +585,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "serde",
@@ -580,16 +597,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -607,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -617,22 +634,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
@@ -674,5 +691,5 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rand_distr = "0.4.3"
 serde = {version = "1.0.137", features = ["derive"]}
 serde_json = "1.0.81"
 sha2 = "0.10.5"
-wasm-bindgen = "0.2.80"
+wasm-bindgen = "= 0.2.87"
 wasm-bindgen-futures = "0.4.30"
 web-sys = { version = "0.3.57", features = ["Clipboard", "Navigator"] }
 yew = "0.19.3"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,183 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1691423162,
+        "narHash": "sha256-cReUZCo83YEEmFcHX8CcOVTZYUrcWgHQO34zxQzy7WI=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b5d9d42ea3fa8fea1805d9af1416fe207d0dd1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1691625043,
+        "narHash": "sha256-IiiOwgRTQm9W1QHe8qme7qYxDbAT2MYxbIJMfPEltN0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3d6ebeb283be256f008541ce2b089eb5fb0e4e01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1691029059,
+        "narHash": "sha256-QwVeE9YTgH3LmL7yw2V/hgswL6yorIvYSp4YGI8lZYM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "99df4908445be37ddb2d332580365fce512a7dcf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1691634013,
+        "narHash": "sha256-EYrZnyYO84mewPetfjxloLKq4WIwmsXUNWnaHhdeO/Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "48f3d76f512c7267d82d84c5d3d156ad2b9a8d12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -95,13 +95,15 @@
           drv = serve-memoradical;
         };
 
-        devShells.default = pkgs.mkShell {
-          inputsFrom = builtins.attrValues self.checks;
-          nativeBuildInputs = with pkgs; [
-            cargo
-            rustc
-            trunk
-          ];
-        };
+        devShells.default = pkgs.mkShell
+          {
+            inputsFrom = builtins.attrValues self.checks;
+            nativeBuildInputs = with pkgs; [
+              cargo
+              rustc
+              trunk
+              rust-analyzer
+            ];
+          } // commonArgs;
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,107 @@
+{
+  description = "Memoradical: A no-frills local-only notecard app";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        inherit (pkgs) lib;
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          # Set the build targets supported by the toolchain,
+          # wasm32-unknown-unknown is required for trunk
+          targets = [ "wasm32-unknown-unknown" ];
+        };
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        # When filtering sources, we want to allow assets other than .rs files
+        src = lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            (lib.hasSuffix "\.html" path) ||
+            (lib.hasInfix "/static/" path) ||
+            (craneLib.filterCargoSources path type)
+          ;
+        };
+
+        commonArgs = {
+          inherit src;
+          CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
+          RUSTFLAGS = "--cfg=web_sys_unstable_apis";
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+          # You cannot run cargo test on a wasm build
+          doCheck = false;
+        });
+
+        memoradical = craneLib.buildTrunkPackage (commonArgs // {
+          inherit cargoArtifacts;
+        });
+
+        serve-memoradical = pkgs.writeShellScriptBin "serve-memoradical" ''
+          ${pkgs.python3Minimal}/bin/python3 -m http.server --directory ${memoradical} 8000
+        '';
+      in
+      {
+        checks = {
+          # Build the crate as part of `nix flake check` for convenience
+          inherit memoradical;
+
+          # Run clippy (and deny all warnings) on the crate source,
+          # again, reusing the dependency artifacts from above.
+          #
+          # Note that this is done as a separate derivation so that
+          # we can block the CI if there are issues here, but not
+          # prevent downstream consumers from building our crate by itself.
+          memoradical-clippy = craneLib.cargoClippy (commonArgs // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+
+          # Check formatting
+          memoradical-fmt = craneLib.cargoFmt {
+            inherit src;
+          };
+        };
+
+        packages.deps = cargoArtifacts;
+        packages.default = memoradical;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = serve-memoradical;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.checks;
+          nativeBuildInputs = with pkgs; [
+            cargo
+            rustc
+            trunk
+          ];
+        };
+      });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,15 @@ impl Face {
     }
 }
 
+
+impl fmt::Display for Face {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let dbg = format!("{:?}", self).to_lowercase();
+        write!(f, "{}", dbg)
+    }
+}
+
+
 struct Model {
     cards: Vec<Card>,
     choose_missed: bool,
@@ -1010,15 +1019,13 @@ impl Component for Model {
             } else {
                 self.visible_face.clone()
             };
-            let (text, bg_color) = match face {
-                Face::Prompt => (card.prompt.clone(), "#EEE8AA"),
-                Face::Response => (card.response.clone(), "#C1FFC1"),
+            let text = match face {
+                Face::Prompt => card.prompt.clone(),
+                Face::Response => card.response.clone()
             };
-            let style = format!("background-color: {bg_color}; font-size: large; padding: 3em");
+            let cls = format!("card {}", face.to_string());
             html! {
-                <>
-                    <p style={style}>{text}</p>
-                </>
+                <p class={cls}>{text}</p>
             }
         } else {
             html! {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::LinkedList;
+use std::fmt;
+use std::string::String;
 
 use anyhow::{anyhow, Context, Result};
 use gloo_console::console_dbg;
@@ -62,7 +64,7 @@ enum Msg {
     UploadCards(Vec<File>),
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 enum Mode {
     Add,
     AllCards,
@@ -70,6 +72,13 @@ enum Mode {
     Help,
     Stats,
     Study,
+}
+
+impl fmt::Display for Mode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let dbg = format!("{:?}", self).to_lowercase();
+        write!(f, "{}", dbg)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1092,7 +1101,7 @@ impl Component for Model {
                     });
                 }
                 html! {
-                    <div id="memoradical">
+                    <div id="memoradical" class="memoradical-cards">
                         {mode_buttons}
                         {upload_html}
                         <table class="striped">
@@ -1108,7 +1117,7 @@ impl Component for Model {
             Mode::Help => {
                 let title = format!("Memoradical v{}", env!("CARGO_PKG_VERSION"));
                 html! {
-                    <div id="memoradical">
+                    <div id="memoradical" class="memoradical-help">
                         {mode_buttons}
                         <h2>{title}</h2>
                         <p>{"Here is some help for "}<a href="https://github.com/ecashin/memoradical">{"Memoradical"}</a>{"."}</p>
@@ -1149,7 +1158,7 @@ impl Component for Model {
                     }
                 };
                 html! {
-                    <div id="memoradical">
+                    <div id="memoradical" class="memoradical-stats">
                         {mode_buttons}
                         {reverse_mode_html}
                         {clear_html}
@@ -1160,7 +1169,7 @@ impl Component for Model {
             Mode::Study => {
                 let choice_checkboxes_html = self.study_checkboxes(ctx);
                 html! {
-                    <div id="memoradical" {onkeypress}>
+                    <div id="memoradical" class="memoradical-study" {onkeypress}>
                         {mode_buttons}
                         <br/>
                         {reverse_mode_html}
@@ -1177,8 +1186,13 @@ impl Component for Model {
                 }
             }
             Mode::Add | Mode::Edit => {
+                let root_cls = format!(
+                    "memoradical-{}",
+                    self.mode.to_string()
+                );
+
                 html! {
-                    <div id="memoradical">
+                    <div id="memoradical" class={root_cls}>
                         {mode_buttons}
                         {add_card_html}
                     </div>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1115,6 +1115,8 @@ impl Component for Model {
                             <tr>
                                 <th>{"Prompt"}</th>
                                 <th>{"Response"}</th>
+                                <th colspan=2>{"Actions"}</th>
+
                             </tr>
                             {cards_html}
                         </table>

--- a/src/main.rs
+++ b/src/main.rs
@@ -977,13 +977,13 @@ impl Component for Model {
             };
         }
         let mode_buttons = html! {
-            <div>
+            <nav>
                 <button disabled={self.mode == Mode::Help} onclick={ctx.link().callback(|_| Msg::HelpMode)}>{"Help"}</button>
                 <button disabled={self.mode == Mode::Study} onclick={ctx.link().callback(|_| Msg::StudyMode)}>{"Study"}</button>
                 <button disabled={self.mode == Mode::Add || self.mode == Mode::Edit} onclick={ctx.link().callback(|_| Msg::AddMode)}>{"Add Card"}</button>
                 <button disabled={self.mode == Mode::AllCards} onclick={ctx.link().callback(|_| Msg::AllCardsMode)}>{"All Cards"}</button>
                 <button disabled={self.mode == Mode::Stats} onclick={ctx.link().callback(|_| Msg::StatsMode)}>{"Stats"}</button>
-            </div>
+            </nav>
         };
         let add_card_html = html! {
             <div>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1092,7 +1092,7 @@ impl Component for Model {
                     });
                 }
                 html! {
-                    <div>
+                    <div id="memoradical">
                         {mode_buttons}
                         {upload_html}
                         <table class="striped">
@@ -1108,7 +1108,7 @@ impl Component for Model {
             Mode::Help => {
                 let title = format!("Memoradical v{}", env!("CARGO_PKG_VERSION"));
                 html! {
-                    <div>
+                    <div id="memoradical">
                         {mode_buttons}
                         <h2>{title}</h2>
                         <p>{"Here is some help for "}<a href="https://github.com/ecashin/memoradical">{"Memoradical"}</a>{"."}</p>
@@ -1149,7 +1149,7 @@ impl Component for Model {
                     }
                 };
                 html! {
-                    <div>
+                    <div id="memoradical">
                         {mode_buttons}
                         {reverse_mode_html}
                         {clear_html}
@@ -1178,7 +1178,7 @@ impl Component for Model {
             }
             Mode::Add | Mode::Edit => {
                 html! {
-                    <div>
+                    <div id="memoradical">
                         {mode_buttons}
                         {add_card_html}
                     </div>

--- a/static/memoradical.css
+++ b/static/memoradical.css
@@ -1,5 +1,5 @@
 table.striped tr:nth-of-type(odd) {
-    background-color: #dde;
+    background-color: slategray;
     padding: 1ex;
 }
 

--- a/static/memoradical.css
+++ b/static/memoradical.css
@@ -109,3 +109,16 @@ p {
     margin-left: 1rem;
     color: red;
 }
+
+.card {
+    font-size: large;
+    padding: 3em;
+}
+
+.card.prompt {
+    background-color: #eee8aa;
+}
+
+.card.response {
+    background-color: #c1ffc1;
+}

--- a/static/memoradical.css
+++ b/static/memoradical.css
@@ -46,6 +46,8 @@ html {
 
 /* main content */
 body {
+    width: 40rem;
+    padding: 1rem;
     max-width: 40rem;
     margin: 0 auto;
     background-color: lightslategray;
@@ -71,12 +73,16 @@ p {
 }
 
 /* nav div */
-#memoradical div:first-child {
+nav {
     border-bottom: 1px solid slategray;
     background-color: floralwhite;
+    top: -1rem;
+    left: -1rem;
+    position: relative;
+    width: calc(100% + 2rem);
 }
 
-#memoradical div:first-child button {
+nav button {
     height: 3rem;
     background-color: slategray;
     border-right: 1px solid black;
@@ -87,11 +93,11 @@ p {
     border-bottom: 1px solid slategray;
 }
 
-#memoradical div:first-child button:first-of-type {
+nav button:first-of-type {
     margin-left: 0;
 }
 
-#memoradical div:first-child button:disabled {
+#memoradical nav button:disabled {
     background-color: lightslategray;
     color: floralwhite;
     font-weight: bold;


### PR DESCRIPTION
This PR fixes a lot of small nits, but should be good to cherry pick individual commits.
If you find it difficult, please let me know and i should be able to re-write history to accommodate.

* Most controversially, this adds a nix flake for easing development
* Individual elements receive new html wrappers, classes, or ids as appropriate to aid in styling.
* Move hardcoded styles out into css file
* Fix contrast for the alternating table rows

Notably, this does *not* yet fix the styling on the help page.
Not sure how you want to do that. 
I had considered styling the individual `<p>`s on that page as cards, but I'm not sure that looks good. 

We can discuss the help page here and I can push new changes as deemed appropriate.

(I haven't attached screenshots as this makes the page look exactly as shown in #37)