### PR TITLE
Increase legibility of help text

### DIFF
--- a/static/memoradical.css
+++ b/static/memoradical.css
@@ -129,10 +129,6 @@ nav button:first-of-type {
     background-color: #c1ffc1;
 }
 
-.memoradical-help {
-    font-family: system-ui;
-}
-
 .memoradical-help p {
     color: black;
     font-size: large;

--- a/static/memoradical.css
+++ b/static/memoradical.css
@@ -128,3 +128,14 @@ nav button:first-of-type {
 .card.response {
     background-color: #c1ffc1;
 }
+
+.memoradical-help {
+    font-family: system-ui;
+}
+
+.memoradical-help p {
+    color: black;
+    font-size: large;
+    padding: 1rem;
+    text-align: left;
+}


### PR DESCRIPTION
These changes improve the contrast of text in help mode and use left alignment.  A daughter complained about the font and selected "system-ui" as a replacement.
**After**
![20230813-help-style](https://github.com/ecashin/memoradical/assets/1819269/3cea8882-b18f-4c52-a6bc-fbde39dcf2d6)

**Before**
![20230813-before](https://github.com/ecashin/memoradical/assets/1819269/ef032813-6ac6-46b0-a981-3dd0417c4858)
